### PR TITLE
Update `is` proptype from oneOf -> oneOfType

### DIFF
--- a/src/BoxShadow.js
+++ b/src/BoxShadow.js
@@ -31,7 +31,7 @@ const BoxShadow = ({
 }
 
 BoxShadow.propTypes = {
-  is: PropTypes.oneOf([PropTypes.string, PropTypes.function]),
+  is: PropTypes.oneOfType([PropTypes.string, PropTypes.function]),
   inset: PropTypes.boolean,
   offsetX: PropTypes.number,
   offsetY: PropTypes.number,


### PR DESCRIPTION
`oneOfType` is used when listing high-level PropTypes opposed to discrete values. `oneOf` would only be used if you had done something like `PropTypes.oneOf(['div', 'span']),`.